### PR TITLE
Improved routing syntax

### DIFF
--- a/Snell/DemoProject/Controllers/DemoController.swift
+++ b/Snell/DemoProject/Controllers/DemoController.swift
@@ -9,11 +9,9 @@
 import Foundation
 
 class DemoController: Controller {
-  // Internal controller subclasses allow for shared controller functionality in a single class/file.
-
-  class Main : DemoController {
-    internal override func run() -> Response {
-      return render(Demo.self, status: 200)
-    }
+  
+  func index() -> Response {
+    return render(Demo.self, status: 200)
   }
+  
 }

--- a/Snell/DemoProject/DemoRouter.swift
+++ b/Snell/DemoProject/DemoRouter.swift
@@ -14,9 +14,9 @@ class DemoRouter : Router {
   override init() {
     super.init()
 
-    // Route the homepage to the "DemoController.Main" action
+    // Route the homepage to the "DemoController.index" action
 
-    route("/", controller: DemoController.Main.self)
+    route("/", to: DemoController.index)
 
     // Route "/closure" to a demo of defining an action as a closure, rather than a controller
 

--- a/Snell/SnellCore/Controller.swift
+++ b/Snell/SnellCore/Controller.swift
@@ -6,6 +6,8 @@
 //  Copyright © 2015 artificial. All rights reserved.
 //
 
+import Foundation
+
 public class Controller {
   public var request:Request
 

--- a/Snell/SnellCore/Router.swift
+++ b/Snell/SnellCore/Router.swift
@@ -6,14 +6,17 @@
 //  Copyright © 2015 artificial. All rights reserved.
 //
 
+import Foundation
+
 public class Router {
+  
   public var routingTable:[NSRegularExpression:(request:Request) -> Response] = [:]
 
   public init() {
   }
 
-  public func route(pattern:String, controller:Controller.Type) {
-    route(pattern, closure: { request in controller(request: request).run() })
+  public func route<T: Controller>(pattern:String, to action:(T) -> () -> Response) {
+    route(pattern, closure: { request in action(T(request: request))() })
   }
 
   public func route(pattern:String, closure: (request:Request) -> Response) {


### PR DESCRIPTION
Uses normal controller methods instead of single-method internal subclasses.
Simpler and more railsy.

Example: route(“/path”, to: MyController.action)
